### PR TITLE
use Str<'a> instead of String for CLEF keys

### DIFF
--- a/sqelf/src/process/clef.rs
+++ b/sqelf/src/process/clef.rs
@@ -42,7 +42,7 @@ pub(super) struct Message<'a> {
 
     // Everything else
     #[serde(flatten)]
-    pub(super) additional: HashMap<String, Value>,
+    pub(super) additional: HashMap<Str<'a>, Value>,
 }
 
 #[derive(Debug)]

--- a/sqelf/src/process/mod.rs
+++ b/sqelf/src/process/mod.rs
@@ -141,7 +141,7 @@ where
         // because we trust the configuration of the logger ahead of any one event.
         if let Some(additional) = self.additional() {
             for (k, v) in additional {
-                Self::override_value(&mut clef.additional, k.to_owned(), v.clone());
+                Self::override_value(&mut clef.additional, k, v.clone());
             }
         }
 
@@ -175,9 +175,13 @@ where
         clef
     }
 
-    fn override_value(fields: &mut HashMap<String, Value>, name: impl ToString, value: Value) {
-        if let Some(old) = fields.insert(name.to_string(), value) {
-            fields.insert(format!("__{}", name.to_string()), old);
+    fn override_value<'a>(
+        fields: &mut HashMap<Str<'a>, Value>,
+        name: &'a (impl AsRef<str> + ?Sized),
+        value: Value,
+    ) {
+        if let Some(old) = fields.insert(Str::Borrowed(name.as_ref()), value) {
+            fields.insert(Str::Owned(format!("__{}", name.as_ref())), old);
         }
     }
 

--- a/sqelf/src/process/str.rs
+++ b/sqelf/src/process/str.rs
@@ -1,4 +1,9 @@
-use std::{fmt, ops::Deref};
+use std::{
+    cmp::{Ord, Ordering, PartialOrd},
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
 
 use serde::{
     de::{self, Deserialize, Deserializer, Visitor},
@@ -28,6 +33,49 @@ where
             Str::Borrowed(s) => s,
             Str::Owned(ref s) => s.as_ref(),
         }
+    }
+}
+
+impl<'a, 'b, SA, SB> PartialEq<Str<'b, SB>> for Str<'a, SA>
+where
+    SA: AsRef<str>,
+    SB: AsRef<str>,
+{
+    fn eq(&self, other: &Str<'b, SB>) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl<'a, S> Eq for Str<'a, S> where Str<'a, S>: PartialEq {}
+
+impl<'a, S> Hash for Str<'a, S>
+where
+    S: AsRef<str>,
+{
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.as_ref().hash(state)
+    }
+}
+
+impl<'a, 'b, SA, SB> PartialOrd<Str<'b, SB>> for Str<'a, SA>
+where
+    SA: AsRef<str>,
+    SB: AsRef<str>,
+{
+    fn partial_cmp(&self, other: &Str<'b, SB>) -> Option<Ordering> {
+        self.as_ref().partial_cmp(other.as_ref())
+    }
+}
+
+impl<'a, S> Ord for Str<'a, S>
+where
+    S: AsRef<str>,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_ref().cmp(other.as_ref())
     }
 }
 


### PR DESCRIPTION
Avoids copying keys around when we don't need to while mapping from GELF to CLEF.

Top level keys should always be borrowed unless they collide and need to be changed.