### PR TITLE
Commit more sins in an attempt to make server shutdown within Seq

### DIFF
--- a/sqelf/src/diagnostics.rs
+++ b/sqelf/src/diagnostics.rs
@@ -50,8 +50,18 @@ pub(crate) fn emit_abort<TInner>(message_template: &'static str) -> impl Fn(TInn
 where
     TInner: Display,
 {
-    move |err| {
-        emit_err(&err, message_template);
+   emit_abort_with(message_template, || ())
+}
+
+/// For use with `map_err`
+pub(crate) fn emit_abort_with<TInner, TError>(message_template: &'static str, err: impl Fn() -> TError) -> impl Fn(TInner) -> TError
+where
+    TInner: Display,
+{
+    move |e| {
+        emit_err(&e, message_template);
+
+        err()
     }
 }
 


### PR DESCRIPTION
Returns an `Err` variant for server shutdown in all cases to prevent any dangling futures from blocking process termination. It's a bit of a hack, but is the only way I can currently figure out to coax `tokio` into shutting down the runtime when we ask it to.