### PR TITLE
Add /udp suffix to example port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To run the container:
 $ docker run \
     --rm \
     -it \
-    -p 12201:12201 \
+    -p 12201:12201/udp \
     -e SEQ_ADDRESS=https://seq.example.com \
     datalust/sqelf
 ```


### PR DESCRIPTION
Just fixes up the example in our README not using the right syntax for mapping a UDP port in Docker.