### PR TITLE
Work on container stability

### DIFF
--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -80,7 +80,7 @@ function Invoke-DockerBuild
 {
     Write-BeginStep $MYINVOCATION
 
-    docker build --file dockerfiles/Dockerfile -t sqelf-ci:latest .
+    docker build --no-cache --file dockerfiles/Dockerfile -t sqelf-ci:latest .
     if ($LASTEXITCODE) { exit 1 }
 }
 

--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -6,4 +6,4 @@ if [ $SEQ_API_KEY ]; then
     api_key_arg="-a $SEQ_API_KEY"
 fi
 
-exec bin/sqelf | bin/seqcli/seqcli ingest --send-failure=continue --json -s $SEQ_ADDRESS $api_key_arg
+bin/sqelf | bin/seqcli/seqcli ingest --invalid-data=ignore --send-failure=continue --json -s $SEQ_ADDRESS $api_key_arg

--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # Add an API Key if specified
 api_key_arg=

--- a/sqelf/src/error.rs
+++ b/sqelf/src/error.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt,
     error,
+    any::Any,
 };
 
 pub(crate) type StdError = Box<error::Error + Send + Sync>;
@@ -54,6 +55,18 @@ impl From<Error> for StdError {
 
 pub(crate) fn err_msg(msg: impl fmt::Display) -> Error {
     Error(Inner(msg.to_string()))
+}
+
+pub(crate) fn unwrap_panic(panic: Box<dyn Any + Send + 'static>) ->  Error {
+    if let Some(err) = panic.downcast_ref::<&str>() {
+        return Error(Inner((*err).into()));
+    }
+
+    if let Some(err) = panic.downcast_ref::<String>() {
+        return Error(Inner((*err).clone()))
+    }
+
+    err_msg("unexpected panic (this is a bug)")
 }
 
 macro_rules! bail {

--- a/sqelf/src/main.rs
+++ b/sqelf/src/main.rs
@@ -21,8 +21,14 @@ use self::{
     },
 };
 
+use std::panic::catch_unwind;
+
 fn main() {
-    if let Err(err) = run() {
+    let run_server = catch_unwind(|| run())
+        .map_err(|panic| error::unwrap_panic(panic).into())
+        .and_then(|inner| inner);
+
+    if let Err(err) = run_server {
         emit_err(&err, "GELF input failed");
         std::process::exit(1);
     }


### PR DESCRIPTION
Part of  #38 

Instead of using `exec` to replace the run script with the `sqelf` container, we let the script remain the root process in the container.

Also adds the `invalid-data=ignore` flag to our `seqcli` call so that  any invalid JSON that makes it way through (even though this probably shouldn't happen) don't cause the CLI process to fail.

There are some bash flags around pipes I'll also investigate to make sure if the `seqcli` or `sqelf` processes terminate that it also causes the run script to terminate.