### PR TITLE
Add metrics to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ A `sqelf` container can be configured using the following environment variables:
 | -------- | ----------- | ------- |
 | `SEQ_ADDRESS`| The address of the Seq server to forward events to | `http://localhost:5341` |
 | `SEQ_API_KEY` | The API key to use | - |
-| `GELF_ADDRESS` | The address to bind the UDP GELF server to | `0.0.0.0:12201`
+| `GELF_ADDRESS` | The address to bind the UDP GELF server to | `0.0.0.0:12201` |
+| `GELF_MIN_SELF_LOG_LEVEL` | The internal logging level to use. Valid values include `DEBUG` or `ERROR`. Metrics will be sampled periodically when the level is `DEBUG`. | `ERROR` |
 
 ### Quick local setup with `docker-compose`
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A `sqelf` container can be configured using the following environment variables:
 | `SEQ_ADDRESS`| The address of the Seq server to forward events to | `http://localhost:5341` |
 | `SEQ_API_KEY` | The API key to use | - |
 | `GELF_ADDRESS` | The address to bind the UDP GELF server to | `0.0.0.0:12201` |
-| `GELF_MIN_SELF_LOG_LEVEL` | The internal logging level to use. Valid values include `DEBUG` or `ERROR`. Metrics will be sampled periodically when the level is `DEBUG`. | `ERROR` |
+| `GELF_ENABLE_DIAGNOSTICS` | Whether to enable diagnostic logs and metrics | `False` |
 
 ### Quick local setup with `docker-compose`
 

--- a/seq-input-gelf.d.json
+++ b/seq-input-gelf.d.json
@@ -16,6 +16,11 @@
         "displayName": "GELF address",
         "helpText": "The socket address (IP address and port) on which the input will listen for UDP GELF payloads. The default is `0.0.0.0:12201`.",
         "isOptional": true
+      },
+      "gelfMinSelfLogLevel": {
+        "displayName": "Minimum self log level",
+        "helpText": "Controls the verbosity of diagnostic logs produced by the server. Valid values are `DEBUG` or `ERROR`. If the value is `DEBUG` then metrics will be periodically sampled. The default is `ERROR`.",
+        "isOptional": true
       }
     }
   }

--- a/seq-input-gelf.d.json
+++ b/seq-input-gelf.d.json
@@ -17,9 +17,10 @@
         "helpText": "The socket address (IP address and port) on which the input will listen for UDP GELF payloads. The default is `0.0.0.0:12201`.",
         "isOptional": true
       },
-      "gelfMinSelfLogLevel": {
-        "displayName": "Minimum self log level",
-        "helpText": "Controls the verbosity of diagnostic logs produced by the server. Valid values are `DEBUG` or `ERROR`. If the value is `DEBUG` then metrics will be periodically sampled. The default is `ERROR`.",
+      "enableDiagnostics": {
+        "inputType": "Checkbox",
+        "displayName": "Enable diagnostics",
+        "helpText": "Controls the verbosity of diagnostic logs produced by the server. When enabled metrics will be regularly sampled",
         "isOptional": true
       }
     }

--- a/sqelf/src/diagnostics.rs
+++ b/sqelf/src/diagnostics.rs
@@ -31,7 +31,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            metrics_interval_ms: 5 * 1000 * 60,
+            metrics_interval_ms: 1 * 1000 * 60, // 1 minute
             min_level: Level::Error,
         }
     }
@@ -203,7 +203,7 @@ pub fn emit_metrics() {
         let evt = DiagnosticEvent::new(
             "DEBUG",
             None,
-            "collected GELF server metrics",
+            "Collected GELF server metrics",
             Some(metrics),
         );
         let json = serde_json::to_string(&evt).expect("infallible JSON");

--- a/sqelf/src/diagnostics.rs
+++ b/sqelf/src/diagnostics.rs
@@ -1,5 +1,126 @@
+use crate::error::{err_msg, Error};
 use chrono::{DateTime, Utc};
-use std::fmt::Display;
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    ops::Drop,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc,
+    },
+    thread,
+    time::Duration,
+};
+
+/**
+Diagnostics configuration.
+*/
+#[derive(Debug, Clone)]
+pub struct Config {
+    /**
+    The interval to sample metrics at.
+    */
+    pub metrics_interval_ms: u64,
+    /**
+    The minimum self log level to emit.
+    */
+    pub min_level: Level,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            metrics_interval_ms: 5 * 1000 * 60,
+            min_level: Level::Error,
+        }
+    }
+}
+
+pub(crate) struct Diagnostics {
+    metrics: Option<(mpsc::Sender<()>, thread::JoinHandle<()>)>,
+}
+
+impl Diagnostics {
+    pub fn stop_metrics(&mut self) -> Result<(), Error> {
+        if let Some((tx, handle)) = self.metrics.take() {
+            tx.send(())?;
+
+            handle
+                .join()
+                .map_err(|_| err_msg("failed to join diagnostics handle"))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for Diagnostics {
+    fn drop(&mut self) {
+        if let Some((tx, _)) = self.metrics.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+pub(crate) fn init(config: Config) -> Diagnostics {
+    MIN_LEVEL.set(config.min_level);
+
+    // Only set up metrics if the minimum level is Debug
+    let metrics = if MIN_LEVEL.includes(Level::Debug) {
+        let (tx, rx) = mpsc::channel();
+
+        let metrics_timeout = Duration::from_millis(config.metrics_interval_ms);
+        let handle = thread::spawn(move || loop {
+            match rx.recv_timeout(metrics_timeout) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return,
+                _ => {
+                    emit_metrics();
+                }
+            }
+        });
+
+        Some((tx, handle))
+    } else {
+        None
+    };
+
+    Diagnostics { metrics }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Level {
+    Debug,
+    Error,
+}
+
+impl FromStr for Level {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEBUG" => Ok(Level::Debug),
+            "ERROR" => Ok(Level::Error),
+            _ => Err(err_msg("expected `DEBUG` or `ERROR`")),
+        }
+    }
+}
+
+impl Level {
+    fn to_usize(self) -> usize {
+        match self {
+            Level::Debug => 0,
+            Level::Error => 1,
+        }
+    }
+
+    fn from_usize(v: usize) -> Self {
+        match v {
+            0 => Level::Debug,
+            _ => Level::Error,
+        }
+    }
+}
 
 #[derive(Serialize)]
 struct DiagnosticEvent<'a> {
@@ -15,6 +136,9 @@ struct DiagnosticEvent<'a> {
     #[serde(rename = "@x")]
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<&'a str>,
+
+    #[serde(flatten)]
+    additional: Option<serde_json::Value>,
 }
 
 impl<'a> DiagnosticEvent<'a> {
@@ -22,27 +146,70 @@ impl<'a> DiagnosticEvent<'a> {
         level: &'static str,
         error: Option<&'a str>,
         message_template: &'static str,
+        additional: Option<serde_json::Value>,
     ) -> DiagnosticEvent<'a> {
         DiagnosticEvent {
             timestamp: Utc::now(),
             message_template,
             level,
             error,
+            additional,
         }
     }
 }
 
 pub fn emit(message_template: &'static str) {
-    let evt = DiagnosticEvent::new("DEBUG", None, &message_template);
-    let json = serde_json::to_string(&evt).expect("infallible JSON");
-    eprintln!("{}", json);
+    if MIN_LEVEL.includes(Level::Debug) {
+        let evt = DiagnosticEvent::new("DEBUG", None, &message_template, None);
+        let json = serde_json::to_string(&evt).expect("infallible JSON");
+        eprintln!("{}", json);
+    }
 }
 
 pub fn emit_err(error: &impl Display, message_template: &'static str) {
-    let err_str = format!("{}", error);
-    let evt = DiagnosticEvent::new("ERROR", Some(&err_str), &message_template);
-    let json = serde_json::to_string(&evt).expect("infallible JSON");
-    eprintln!("{}", json);
+    if MIN_LEVEL.includes(Level::Error) {
+        let err_str = format!("{}", error);
+        let evt = DiagnosticEvent::new("ERROR", Some(&err_str), &message_template, None);
+        let json = serde_json::to_string(&evt).expect("infallible JSON");
+        eprintln!("{}", json);
+    }
+}
+
+pub fn emit_metrics() {
+    if MIN_LEVEL.includes(Level::Debug) {
+        #[derive(Serialize)]
+        struct EmitMetrics {
+            receive: HashMap<&'static str, usize>,
+            process: HashMap<&'static str, usize>,
+            server: HashMap<&'static str, usize>,
+        }
+
+        let mut metrics = EmitMetrics {
+            receive: HashMap::new(),
+            process: HashMap::new(),
+            server: HashMap::new(),
+        };
+
+        let receive = METRICS.receive.take();
+        let process = METRICS.process.take();
+        let server = METRICS.server.take();
+
+        metrics.receive.extend(receive.as_ref().iter().cloned());
+        metrics.process.extend(process.as_ref().iter().cloned());
+        metrics.server.extend(server.as_ref().iter().cloned());
+
+        let metrics = serde_json::to_value(metrics).expect("infallible JSON");
+
+        let evt = DiagnosticEvent::new(
+            "DEBUG",
+            None,
+            "collected GELF server metrics",
+            Some(metrics),
+        );
+        let json = serde_json::to_string(&evt).expect("infallible JSON");
+
+        eprintln!("{}", json);
+    }
 }
 
 /// For use with `map_err`
@@ -50,11 +217,14 @@ pub(crate) fn emit_abort<TInner>(message_template: &'static str) -> impl Fn(TInn
 where
     TInner: Display,
 {
-   emit_abort_with(message_template, || ())
+    emit_abort_with(message_template, || ())
 }
 
 /// For use with `map_err`
-pub(crate) fn emit_abort_with<TInner, TError>(message_template: &'static str, err: impl Fn() -> TError) -> impl Fn(TInner) -> TError
+pub(crate) fn emit_abort_with<TInner, TError>(
+    message_template: &'static str,
+    err: impl Fn() -> TError,
+) -> impl Fn(TInner) -> TError
 where
     TInner: Display,
 {
@@ -88,4 +258,75 @@ where
 
         Ok(ok())
     }
+}
+
+pub(crate) struct MinLevel(AtomicUsize);
+pub(crate) static MIN_LEVEL: MinLevel = MinLevel(AtomicUsize::new(0));
+
+impl MinLevel {
+    fn set(&self, min: Level) {
+        MIN_LEVEL.0.store(min.to_usize(), Ordering::Relaxed);
+    }
+
+    fn get(&self) -> Level {
+        Level::from_usize(MIN_LEVEL.0.load(Ordering::Relaxed))
+    }
+
+    pub(crate) fn includes(&self, level: Level) -> bool {
+        level.to_usize() >= self.get().to_usize()
+    }
+}
+
+pub(crate) struct Metrics {
+    pub(crate) receive: crate::receive::Metrics,
+    pub(crate) process: crate::process::Metrics,
+    pub(crate) server: crate::server::Metrics,
+    _private: (),
+}
+
+pub(crate) static METRICS: Metrics = Metrics {
+    receive: crate::receive::Metrics::new(),
+    process: crate::process::Metrics::new(),
+    server: crate::server::Metrics::new(),
+    _private: (),
+};
+
+macro_rules! increment {
+    ($($metric:tt)*) => {{
+        if $crate::diagnostics::MIN_LEVEL.includes($crate::diagnostics::Level::Debug) {
+            $crate::diagnostics::METRICS.$($metric)*.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }};
+}
+
+macro_rules! metrics {
+    ($($metric:ident),*) => {
+        pub(crate) struct Metrics {
+            $(
+                pub(crate) $metric: std::sync::atomic::AtomicUsize,
+            )*
+            _private: (),
+        }
+
+        impl Metrics {
+            pub(crate) const fn new() -> Self {
+                Metrics {
+                    $(
+                        $metric: std::sync::atomic::AtomicUsize::new(0),
+                    )*
+                    _private: (),
+                }
+            }
+
+            pub(crate) fn take(&self) -> impl AsRef<[(&'static str, usize)]> {
+                let fields = [
+                    $(
+                        (stringify!($metric), self.$metric.swap(0, std::sync::atomic::Ordering::Relaxed)),
+                    )*
+                ];
+
+                fields
+            }
+        }
+    };
 }

--- a/sqelf/src/error.rs
+++ b/sqelf/src/error.rs
@@ -1,10 +1,6 @@
-use std::{
-    fmt,
-    error,
-    any::Any,
-};
+use std::{any::Any, error, fmt};
 
-pub(crate) type StdError = Box<error::Error + Send + Sync>;
+pub(crate) type StdError = Box<dyn error::Error + Send + Sync>;
 
 pub struct Error(Inner);
 
@@ -34,9 +30,7 @@ impl fmt::Display for Inner {
     }
 }
 
-impl error::Error for Inner {
-
-}
+impl error::Error for Inner {}
 
 impl<E> From<E> for Error
 where
@@ -57,13 +51,13 @@ pub(crate) fn err_msg(msg: impl fmt::Display) -> Error {
     Error(Inner(msg.to_string()))
 }
 
-pub(crate) fn unwrap_panic(panic: Box<dyn Any + Send + 'static>) ->  Error {
+pub(crate) fn unwrap_panic(panic: Box<dyn Any + Send + 'static>) -> Error {
     if let Some(err) = panic.downcast_ref::<&str>() {
         return Error(Inner((*err).into()));
     }
 
     if let Some(err) = panic.downcast_ref::<String>() {
-        return Error(Inner((*err).clone()))
+        return Error(Inner((*err).clone()));
     }
 
     err_msg("unexpected panic (this is a bug)")

--- a/sqelf/src/main.rs
+++ b/sqelf/src/main.rs
@@ -2,9 +2,11 @@
 extern crate serde_derive;
 
 #[macro_use]
+mod diagnostics;
+
+#[macro_use]
 pub mod error;
 
-mod diagnostics;
 pub mod io;
 pub mod process;
 pub mod receive;
@@ -14,28 +16,19 @@ mod config;
 
 pub use self::config::Config;
 use self::{
-    diagnostics::emit_err,
-    error::{
-        Error,
-        err_msg,
-    },
+    diagnostics::{emit, emit_err},
+    error::{err_msg, Error},
 };
 
 use std::panic::catch_unwind;
 
-fn main() {
-    let run_server = catch_unwind(|| run())
-        .map_err(|panic| error::unwrap_panic(panic).into())
-        .and_then(|inner| inner);
-
-    if let Err(err) = run_server {
-        emit_err(&err, "GELF input failed");
-        std::process::exit(1);
-    }
-}
-
 fn run() -> Result<(), error::StdError> {
     let config = Config::from_env()?;
+
+    // Initialize diagnostics
+    let mut diagnostics = diagnostics::init(config.diagnostics);
+
+    emit("Starting GELF server");
 
     // The receiver for GELF messages
     let receive = {
@@ -53,8 +46,26 @@ fn run() -> Result<(), error::StdError> {
     let server = server::build(config.server, receive, process)?;
 
     // Run the server and wait for it to exit
-    match tokio::runtime::current_thread::block_on_all(server) {
+    let run_server = match tokio::runtime::current_thread::block_on_all(server) {
         Ok(()) | Err(server::Exit::Clean) => Ok(()),
-        _ => Err(err_msg("Server execution failed").into())
+        _ => Err(err_msg("Server execution failed").into()),
+    };
+
+    // Stop diagnostics
+    let stop_diagnostics = diagnostics.stop_metrics().map_err(Into::into);
+
+    run_server.and(stop_diagnostics)
+}
+
+fn main() {
+    let run_server: Result<(), error::StdError> = catch_unwind(|| run())
+        .map_err(|panic| error::unwrap_panic(panic).into())
+        .and_then(|inner| inner);
+
+    if let Err(err) = run_server {
+        emit_err(&err, "GELF input failed");
+        std::process::exit(1);
     }
+
+    emit("GELF input stopped");
 }

--- a/sqelf/src/process/mod.rs
+++ b/sqelf/src/process/mod.rs
@@ -6,12 +6,13 @@ use serde_json::Value;
 
 use self::str::{CachedString, Inlinable, Str};
 
-use crate::{
-    error::Error,
-    io::MemRead,
-};
+use crate::{error::Error, io::MemRead};
 
 use std::collections::HashMap;
+
+metrics! {
+    msg
+}
 
 /**
 Configuration for CELF formatting.
@@ -48,6 +49,8 @@ impl Process {
         msg: impl MemRead,
         with: impl FnOnce(clef::Message) -> Result<(), Error>,
     ) -> Result<(), Error> {
+        increment!(process.msg);
+
         if let Some(bytes) = msg.bytes() {
             let value: gelf::Message<Str> = serde_json::from_slice(bytes)?;
 

--- a/sqelf/src/receive.rs
+++ b/sqelf/src/receive.rs
@@ -50,7 +50,7 @@ impl Default for Config {
         Config {
             incomplete_capacity: 1024,
             max_chunks_per_message: 128,
-            incomplete_timeout_ms: 5 * 1000,
+            incomplete_timeout_ms: 5 * 1000, // 5 seconds
         }
     }
 }

--- a/sqelf/src/receive.rs
+++ b/sqelf/src/receive.rs
@@ -8,10 +8,14 @@ use std::{
 use bytes::{Buf, Bytes, IntoBuf};
 use libflate::{gzip, zlib};
 
-use crate::{
-    error::Error,
-    io::MemRead,
-};
+use crate::{error::Error, io::MemRead};
+
+metrics! {
+    chunk,
+    msg_chunked,
+    msg_unchunked,
+    overflow_incomplete_chunks
+}
 
 /**
 GELF receiver configuration.
@@ -132,11 +136,15 @@ impl Gelf {
         let magic = Message::peek_magic_bytes(&src);
 
         if magic == Some(Message::MAGIC_CHUNKED) {
+            increment!(receive.chunk);
+
             // Push a chunk onto a message
             // If the chunk completes the message then it
             // will be returned
             self.chunked(src)
         } else {
+            increment!(receive.msg_unchunked);
+
             // Return a message containing a single chunk
             Ok(Message::single(magic.and_then(Compression::detect), src))
         }
@@ -183,6 +191,8 @@ impl Gelf {
         // If we're past the threshold then drop *all* chunks,
         // whether they've expired or not.
         if self.by_id.chunks.len() >= self.config.incomplete_capacity {
+            increment!(receive.overflow_incomplete_chunks);
+
             self.by_id.chunks.clear();
             self.by_arrival.chunks.clear();
         }
@@ -235,6 +245,8 @@ impl Gelf {
                 if chunks.is_complete() {
                     let (_, (chunks, arrival)) = entry.remove_entry();
                     self.by_arrival.chunks.remove(&arrival);
+
+                    increment!(receive.msg_chunked);
 
                     Ok(Message::chunked(
                         chunks.inner.into_iter().map(|(_, chunk)| chunk),
@@ -827,7 +839,7 @@ mod tests {
 
         gelf.decode(chunk(0, 0, 3, b"1"))
             .expect("failed to decode message");
-        
+
         gelf.decode(chunk(1, 0, 3, b"2"))
             .expect("failed to decode message");
 


### PR DESCRIPTION
Closes #44 

Introduces metrics to the server along with a configurable self logging level. When that level is `DEBUG` then we'll sample metrics and log them every 5 minutes. These can then be charted on a Seq dashboard to get an idea of how the Gelf server is behaving. The sampling interval is configurable, but isn't surfaced through an environment variable or Seq setting yet.

We don't do any per-event debug logging so increasing the logging verbosity shouldn't have much impact on the runtime.