### PR TITLE
An initial TCP implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A `sqelf` container can be configured using the following environment variables:
 | `SEQ_ADDRESS`| The address of the Seq server to forward events to | `http://localhost:5341` |
 | `SEQ_API_KEY` | The API key to use | - |
 | `GELF_ADDRESS` | The address to bind the UDP GELF server to | `0.0.0.0:12201` |
+| `GELF_PROTOCOL` | The protocol to use. Either `udp` or `tcp`. | `udp` |
 | `GELF_ENABLE_DIAGNOSTICS` | Whether to enable diagnostic logs and metrics | `False` |
 
 ### Quick local setup with `docker-compose`

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ A `sqelf` container can be configured using the following environment variables:
 | -------- | ----------- | ------- |
 | `SEQ_ADDRESS`| The address of the Seq server to forward events to | `http://localhost:5341` |
 | `SEQ_API_KEY` | The API key to use | - |
-| `GELF_ADDRESS` | The address to bind the UDP GELF server to | `0.0.0.0:12201` |
-| `GELF_PROTOCOL` | The protocol to use. Either `udp` or `tcp`. Note: TCP support is experimental. | `udp` |
+| `GELF_ADDRESS` | The address to bind the UDP GELF server to. The protocol may be `udp` or `tcp`. Note: TCP support is experimental | `udp://0.0.0.0:12201` |
 | `GELF_ENABLE_DIAGNOSTICS` | Whether to enable diagnostic logs and metrics | `False` |
 
 ### Quick local setup with `docker-compose`

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A `sqelf` container can be configured using the following environment variables:
 | `SEQ_ADDRESS`| The address of the Seq server to forward events to | `http://localhost:5341` |
 | `SEQ_API_KEY` | The API key to use | - |
 | `GELF_ADDRESS` | The address to bind the UDP GELF server to | `0.0.0.0:12201` |
-| `GELF_PROTOCOL` | The protocol to use. Either `udp` or `tcp`. | `udp` |
+| `GELF_PROTOCOL` | The protocol to use. Either `udp` or `tcp`. Note: TCP support is experimental. | `udp` |
 | `GELF_ENABLE_DIAGNOSTICS` | Whether to enable diagnostic logs and metrics | `False` |
 
 ### Quick local setup with `docker-compose`

--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -124,7 +124,7 @@ function Publish-Container($version)
     if ($LASTEXITCODE) { exit 1 }
 }
 
-function Start-SeqEnvironment {
+function Start-SeqEnvironment($protocol) {
     Write-BeginStep $MYINVOCATION
 
     Push-Location ci/smoke-test
@@ -142,6 +142,11 @@ function Start-SeqEnvironment {
         exit 1
     }
 
+    $portArg = "12201"
+    if ($protocol -eq "udp") {
+        $portArg = "12201/udp"
+    }
+
     docker pull datalust/seq:latest
     docker run --name sqelf-test-seq `
         --network sqelf-test `
@@ -157,8 +162,9 @@ function Start-SeqEnvironment {
     docker run --name sqelf-test-sqelf `
         --network sqelf-test `
         -e SEQ_ADDRESS=http://sqelf-test-seq:5341 `
+        -e GELF_PROTOCOL=$protocol `
         -itd `
-        -p 12202:12201/udp `
+        -p "12202:${portArg}" `
         sqelf-ci:latest
     if ($LASTEXITCODE) {
         Pop-Location
@@ -206,14 +212,14 @@ function Build-TestAppContainer {
     if ($LASTEXITCODE) { exit 1 }
 }
 
-function Invoke-TestApp {
+function Invoke-TestApp($protocol) {
     Write-BeginStep $MYINVOCATION
 
     docker run `
         --rm `
         -i `
         --log-driver gelf `
-        --log-opt gelf-address=udp://localhost:12202 `
+        --log-opt "gelf-address=${protocol}://localhost:12202" `
         sqelf-app-test:latest
     if ($LASTEXITCODE) { exit 1 }
 

--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -162,7 +162,7 @@ function Start-SeqEnvironment($protocol) {
     docker run --name sqelf-test-sqelf `
         --network sqelf-test `
         -e SEQ_ADDRESS=http://sqelf-test-seq:5341 `
-        -e GELF_PROTOCOL=$protocol `
+        -e GELF_ADDRESS="${protocol}://0.0.0.0:12201" `
         -itd `
         -p "12202:${portArg}" `
         sqelf-ci:latest

--- a/ci/linux-x64/build.ps1
+++ b/ci/linux-x64/build.ps1
@@ -7,18 +7,26 @@ Push-Location "$PSScriptRoot/../../"
 
 . "./ci/build-deps.ps1"
 
+function Invoke-SmokeTest($protocol) {
+    Write-BeginStep $MYINVOCATION
+
+    Start-SeqEnvironment($protocol)
+    Invoke-TestApp($protocol)
+    Check-SqelfLogs
+    Check-SeqLogs
+    Check-ClefOutput
+    Stop-SeqEnvironment
+}
+
 Initialize-Filesystem
 Invoke-LinuxBuild
 Invoke-LinuxTests
 Invoke-DockerBuild
 
 Build-TestAppContainer
-Start-SeqEnvironment
-Invoke-TestApp
-Check-SqelfLogs
-Check-SeqLogs
-Check-ClefOutput
-Stop-SeqEnvironment
+
+Invoke-SmokeTest("udp")
+Invoke-SmokeTest("tcp")
 
 if ($IsPublishedBuild) {
     Publish-Container (Get-SemVer $shortver)

--- a/seq-input-gelf.d.json
+++ b/seq-input-gelf.d.json
@@ -14,13 +14,7 @@
     "settings": {
       "gelfAddress": {
         "displayName": "GELF address",
-        "helpText": "The socket address (IP address and port) on which the input will listen for GELF payloads. The default is `0.0.0.0:12201`.",
-        "isOptional": true
-      },
-      "useTcp": {
-        "inputType": "Checkbox",
-        "displayName": "Use TCP",
-        "helpText": "Listen for GELF messages over TCP instead of UDP. TCP support is experimental and is not suitable for direct internet-facing workloads.",
+        "helpText": "The url (protocol, IP address and port) on which the input will listen for GELF payloads. The default is `udp://0.0.0.0:12201`. Specifying the protocol as `tcp` will listen on TCP instead of UDP. TCP support is experimental and is not suitable for direct internet-facing workloads.",
         "isOptional": true
       },
       "enableDiagnostics": {

--- a/seq-input-gelf.d.json
+++ b/seq-input-gelf.d.json
@@ -20,7 +20,7 @@
       "useTcp": {
         "inputType": "Checkbox",
         "displayName": "Use TCP",
-        "helpText": "Listen for GELF messages over TCP instead of UDP.",
+        "helpText": "Listen for GELF messages over TCP instead of UDP. TCP support is experimental and is not suitable for direct internet-facing workloads.",
         "isOptional": true
       },
       "enableDiagnostics": {

--- a/seq-input-gelf.d.json
+++ b/seq-input-gelf.d.json
@@ -14,7 +14,13 @@
     "settings": {
       "gelfAddress": {
         "displayName": "GELF address",
-        "helpText": "The socket address (IP address and port) on which the input will listen for UDP GELF payloads. The default is `0.0.0.0:12201`.",
+        "helpText": "The socket address (IP address and port) on which the input will listen for GELF payloads. The default is `0.0.0.0:12201`.",
+        "isOptional": true
+      },
+      "useTcp": {
+        "inputType": "Checkbox",
+        "displayName": "Use TCP",
+        "helpText": "Listen for GELF messages over TCP instead of UDP.",
         "isOptional": true
       },
       "enableDiagnostics": {

--- a/sqelf/src/config.rs
+++ b/sqelf/src/config.rs
@@ -29,7 +29,7 @@ impl Config {
         } else {
             read_environment(&mut config.server.protocol, "GELF_PROTOCOL")?;
         };
-        
+
         let enable_diagnostics = if is_seq_app {
             "SEQ_APP_SETTING_ENABLEDIAGNOSTICS"
         } else {

--- a/sqelf/src/config.rs
+++ b/sqelf/src/config.rs
@@ -22,13 +22,14 @@ impl Config {
         };
         read_environment(&mut config.server.bind, bind_address_var)?;
 
-        let protocol_var = if is_seq_app {
-            "SEQ_APP_SETTING_PROTOCOL"
+        if is_seq_app {
+            if is_truthy("SEQ_APP_SETTING_USETCP")? {
+                config.server.protocol = server::Protocol::Tcp;
+            }
         } else {
-            "GELF_PROTOCOL"
+            read_environment(&mut config.server.protocol, "GELF_PROTOCOL")?;
         };
-        read_environment(&mut config.server.protocol, protocol_var)?;
-
+        
         let enable_diagnostics = if is_seq_app {
             "SEQ_APP_SETTING_ENABLEDIAGNOSTICS"
         } else {

--- a/sqelf/src/config.rs
+++ b/sqelf/src/config.rs
@@ -22,14 +22,6 @@ impl Config {
         };
         read_environment(&mut config.server.bind, bind_address_var)?;
 
-        if is_seq_app {
-            if is_truthy("SEQ_APP_SETTING_USETCP")? {
-                config.server.protocol = server::Protocol::Tcp;
-            }
-        } else {
-            read_environment(&mut config.server.protocol, "GELF_PROTOCOL")?;
-        };
-
         let enable_diagnostics = if is_seq_app {
             "SEQ_APP_SETTING_ENABLEDIAGNOSTICS"
         } else {

--- a/sqelf/src/config.rs
+++ b/sqelf/src/config.rs
@@ -22,6 +22,13 @@ impl Config {
         };
         read_environment(&mut config.server.bind, bind_address_var)?;
 
+        let protocol_var = if is_seq_app {
+            "SEQ_APP_SETTING_PROTOCOL"
+        } else {
+            "GELF_PROTOCOL"
+        };
+        read_environment(&mut config.server.protocol, protocol_var)?;
+
         let enable_diagnostics = if is_seq_app {
             "SEQ_APP_SETTING_ENABLEDIAGNOSTICS"
         } else {

--- a/sqelf/src/process/mod.rs
+++ b/sqelf/src/process/mod.rs
@@ -36,7 +36,7 @@ pub fn build(config: Config) -> Process {
 /**
 Process a raw message
 */
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Process {}
 
 impl Process {

--- a/sqelf/src/receive.rs
+++ b/sqelf/src/receive.rs
@@ -69,14 +69,14 @@ A message may be chunked and compressed.
 This decoder won't attempt to validate that the contents
 of the message itself conforms to the GELF specification.
 */
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Gelf {
     config: Config,
     by_id: ById,
     by_arrival: ByArrival,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct ById {
     chunks: HashMap<u64, (Chunks, UniqueTimestamp)>,
 }
@@ -89,7 +89,7 @@ impl ById {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct ByArrival {
     counter: u64,
     chunks: BTreeMap<UniqueTimestamp, u64>,
@@ -259,12 +259,13 @@ impl Gelf {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Chunks {
     expected_total: u8,
     inner: BTreeMap<u8, Bytes>,
 }
 
+#[derive(Debug, Clone)]
 struct Chunk {
     seq: u8,
     bytes: Bytes,

--- a/tests/src/cases/mod.rs
+++ b/tests/src/cases/mod.rs
@@ -1,4 +1,6 @@
 cases! {
-    empty,
-    simple
+    udp_empty,
+    udp_simple,
+
+    tcp_simple
 }

--- a/tests/src/cases/tcp_simple.rs
+++ b/tests/src/cases/tcp_simple.rs
@@ -1,14 +1,15 @@
 use crate::support::*;
 
 pub fn test() {
-    expect(
+    tcp_expect(
         ToReceive {
             count: 1,
-            when_sending: dgrams![
-                ..dgrams!({
+            when_sending: net_chunks![
+                ..net_chunks!({
                     "host": "foo",
                     "short_message": "bar"
-                })
+                }),
+                ..tcp_delim()
             ],
         },
         |received| {

--- a/tests/src/cases/udp_empty.rs
+++ b/tests/src/cases/udp_empty.rs
@@ -1,7 +1,7 @@
 use crate::support::*;
 
 pub fn test() {
-    expect(
+    udp_expect(
         ToReceive {
             count: 0,
             when_sending: vec![],

--- a/tests/src/cases/udp_simple.rs
+++ b/tests/src/cases/udp_simple.rs
@@ -1,0 +1,18 @@
+use crate::support::*;
+
+pub fn test() {
+    udp_expect(
+        ToReceive {
+            count: 1,
+            when_sending: net_chunks![
+                ..net_chunks!({
+                    "host": "foo",
+                    "short_message": "bar"
+                })
+            ],
+        },
+        |received| {
+            assert_eq!("bar", received[0]["@m"]);
+        },
+    );
+}

--- a/tests/src/support.rs
+++ b/tests/src/support.rs
@@ -38,8 +38,10 @@ fn expect(protocol: server::Protocol, to_receive: ToReceive, check: impl Fn(&[Va
     // Build a server
     let mut server = server::build(
         server::Config {
-            bind: "0.0.0.0:12202".into(),
-            protocol,
+            bind: server::Bind {
+                addr: "0.0.0.0:12202".into(),
+                protocol,
+            },
             ..Default::default()
         },
         {


### PR DESCRIPTION
Part of #48 

Adds TCP as a protocol we can use to listen for messages on. It's similar to UDP, but because messages are null terminated it doesn't support compression. We can use the same receive logic though, there are just some features that won't be included.

This needs a bunch more integration tests and a good burn in.