### PR TITLE
Rework tcp buffer management

### DIFF
--- a/sqelf/src/lib.rs
+++ b/sqelf/src/lib.rs
@@ -13,11 +13,11 @@ pub mod diagnostics;
 #[macro_use]
 pub mod error;
 
+pub mod config;
 pub mod io;
 pub mod process;
 pub mod receive;
 pub mod server;
-pub mod config;
 
 pub use self::{
     config::Config,

--- a/sqelf/src/main.rs
+++ b/sqelf/src/main.rs
@@ -3,23 +3,26 @@
 extern crate sqelf;
 
 use sqelf::{
-    config::{self, Config},
-    receive,
-    process,
+    config::{
+        self,
+        Config,
+    },
     diagnostics::{
         self,
         emit,
         emit_err,
     },
     error::Error,
+    process,
+    receive,
     server,
 };
 
 use std::{
+    any::Any,
     io::Read,
     panic::catch_unwind,
     thread,
-    any::Any,
 };
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {

--- a/sqelf/src/receive.rs
+++ b/sqelf/src/receive.rs
@@ -35,7 +35,7 @@ metrics! {
     chunk,
     msg_chunked,
     msg_unchunked,
-    overflow_incomplete_chunks
+    msg_incomplete_chunk_overflow
 }
 
 /**
@@ -212,7 +212,7 @@ impl Gelf {
         // If we're past the threshold then drop *all* chunks,
         // whether they've expired or not.
         if self.by_id.chunks.len() >= self.config.incomplete_capacity {
-            increment!(receive.overflow_incomplete_chunks);
+            increment!(receive.msg_incomplete_chunk_overflow);
 
             self.by_id.chunks.clear();
             self.by_arrival.chunks.clear();

--- a/tests/src/cases/mod.rs
+++ b/tests/src/cases/mod.rs
@@ -8,5 +8,12 @@ cases! {
     tcp_simple,
     tcp_invalid,
     tcp_partial,
-    tcp_chunked_simple
+    tcp_huge,
+    tcp_overflow,
+    tcp_overflow_huge,
+    tcp_chunked_simple,
+    tcp_multiple_frames,
+    tcp_multiple_frames_single_write,
+    tcp_multiple_conns,
+    tcp_multiple_conns_partial
 }

--- a/tests/src/cases/tcp_huge.rs
+++ b/tests/src/cases/tcp_huge.rs
@@ -1,0 +1,27 @@
+use std::str;
+
+use crate::support::*;
+
+pub fn test() {
+    let mut server = server::builder().tcp_max_size_bytes(1024 * 32).tcp();
+    let mut stream = tcp::stream();
+
+    let short_message = str::from_utf8(&[b'a'; 1024 * 12]).unwrap();
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": short_message
+        }),
+        ..tcp_delim()
+    ]);
+
+    server.receive(|received| {
+        assert_eq!(short_message, received["@m"]);
+    });
+
+    assert_eq!(1, server.received());
+
+    stream.close();
+    server.close();
+}

--- a/tests/src/cases/tcp_multiple_conns.rs
+++ b/tests/src/cases/tcp_multiple_conns.rs
@@ -1,0 +1,32 @@
+use crate::support::*;
+
+pub fn test() {
+    let mut server = server::tcp();
+    let mut stream1 = tcp::stream();
+    let mut stream2 = tcp::stream();
+
+    stream1.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim()
+    ]);
+
+    stream2.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim()
+    ]);
+
+    server.receive(|_| { });
+    server.receive(|_| { });
+
+    assert_eq!(2, server.received());
+
+    stream1.close();
+    stream2.close();
+    server.close();
+}

--- a/tests/src/cases/tcp_multiple_conns_partial.rs
+++ b/tests/src/cases/tcp_multiple_conns_partial.rs
@@ -1,0 +1,24 @@
+use crate::support::*;
+
+pub fn test() {
+    let mut server = server::tcp();
+    let mut stream1 = tcp::stream();
+    let mut stream2 = tcp::stream();
+
+    stream1.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        })
+    ]);
+
+    stream2.write(net_chunks![
+        ..tcp_delim()
+    ]);
+
+    assert_eq!(0, server.received());
+
+    stream1.close();
+    stream2.close();
+    server.close();
+}

--- a/tests/src/cases/tcp_multiple_frames.rs
+++ b/tests/src/cases/tcp_multiple_frames.rs
@@ -1,0 +1,30 @@
+use crate::support::*;
+
+pub fn test() {
+    let mut server = server::tcp();
+    let mut stream = tcp::stream();
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim()
+    ]);
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim()
+    ]);
+
+    server.receive(|_| { });
+    server.receive(|_| { });
+
+    assert_eq!(2, server.received());
+
+    stream.close();
+    server.close();
+}

--- a/tests/src/cases/tcp_multiple_frames_single_write.rs
+++ b/tests/src/cases/tcp_multiple_frames_single_write.rs
@@ -1,0 +1,27 @@
+use crate::support::*;
+
+pub fn test() {
+    let mut server = server::tcp();
+    let mut stream = tcp::stream();
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim(),
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim()
+    ]);
+
+    server.receive(|_| { });
+    server.receive(|_| { });
+
+    assert_eq!(2, server.received());
+
+    stream.close();
+    server.close();
+}

--- a/tests/src/cases/tcp_overflow.rs
+++ b/tests/src/cases/tcp_overflow.rs
@@ -1,0 +1,35 @@
+use std::str;
+
+use crate::support::*;
+
+pub fn test() {
+    let mut server = server::tcp();
+    let mut stream = tcp::stream();
+
+    let short_message = str::from_utf8(&[b'a'; 1024]).unwrap();
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": short_message
+        }),
+        ..tcp_delim()
+    ]);
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim()
+    ]);
+
+    server.receive(|received| {
+        assert_eq!("bar", received["@m"]);
+    });
+
+    assert_eq!(1, server.received());
+
+    stream.close();
+    server.close();
+}

--- a/tests/src/cases/tcp_overflow_huge.rs
+++ b/tests/src/cases/tcp_overflow_huge.rs
@@ -1,0 +1,35 @@
+use std::str;
+
+use crate::support::*;
+
+pub fn test() {
+    let mut server = server::tcp();
+    let mut stream = tcp::stream();
+
+    let short_message = str::from_utf8(&[b'a'; 1024 * 16]).unwrap();
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": short_message
+        }),
+        ..tcp_delim()
+    ]);
+
+    stream.write(net_chunks![
+        ..net_chunks!({
+            "host": "foo",
+            "short_message": "bar"
+        }),
+        ..tcp_delim()
+    ]);
+
+    server.receive(|received| {
+        assert_eq!("bar", received["@m"]);
+    });
+
+    assert_eq!(1, server.received());
+
+    stream.close();
+    server.close();
+}


### PR DESCRIPTION
Part of #58 

We've been holding `tokio`'s `Decoder` API incorrectly by not appropriately advancing the buffer. It also appears that things get poisoned in case an error is returned. This PR cleans things up a few ways:

- Appropriately return `Ok(None)` from our `tcp::Decoder` whenever we haven't produced a complete frame.
- Add a size limit to tcp frames (guaranteeing we won't ever consume roughly more than `tcp_max_size_bytes` of memory per connection). It's set at 256KiB and could be exposed as a configuration setting. In case we're discarding data, we'll end up using 8KiB buffers instead of the possible 256KiB one while looking for the end of the message.
- Don't put connections back in our pool if they produce an error. This is a bit conservative, because some errors would be recoverable, but right now we'll drop them and log an error.
- Adds a bunch of new integration tests for tcp.