### PR TITLE
rename from sqelf to seq-input-gelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Events ingested by the input will be associated with the default _None_ [API key
 
 ## Getting started with Docker (all versions)
 
-For Docker, the app is deployed as a Docker container that is expected to run alongside the Seq container. The `datalust/sqelf` container accepts GELF messages (via UDP on port 12201 by default), and forwards them to the Seq ingestion endpoint specified in the `SEQ_ADDRESS` environment variable.
+For Docker, the app is deployed as a Docker container that is expected to run alongside the Seq container. The `datalust/seq-input-gelf` container accepts GELF messages (via UDP on port 12201 by default), and forwards them to the Seq ingestion endpoint specified in the `SEQ_ADDRESS` environment variable.
 
 To run the container:
 
@@ -41,15 +41,15 @@ $ docker run \
     --rm \
     -it \
     -p 12201:12201/udp \
-    -e SEQ_ADDRESS=https://seq.example.com \
-    datalust/sqelf
+    -e SEQ_ADDRESS=https://seq.example.com:5341 \
+    datalust/seq-input-gelf
 ```
 
-The container is published on Docker Hub as [`datalust/sqelf`](https://hub.docker.com/r/datalust/sqelf).
+The container is published on Docker Hub as [`datalust/seq-input-gelf`](https://hub.docker.com/r/datalust/seq-input-gelf), previously [`datalust/sqelf` (still updated, for backwards-compatibility)](https://hub.docker.com/r/datalust/sqelf).
 
 ### Container configuration
 
-A `sqelf` container can be configured using the following environment variables:
+A `seq-input-gelf` container can be configured using the following environment variables:
 
 | Variable | Description | Default |
 | -------- | ----------- | ------- |
@@ -60,13 +60,13 @@ A `sqelf` container can be configured using the following environment variables:
 
 ### Quick local setup with `docker-compose`
 
-The following is an example `docker-compose` file that can be used to manage a local Seq container alongside `sqelf` in your development environment to collect log events from other containers:
+The following is an example `docker-compose` file that can be used to manage a local Seq container alongside `seq-input-gelf` in your development environment to collect log events from other containers:
 
 ```yaml
 version: '3'
 services:
-  sqelf:
-    image: datalust/sqelf:latest
+  seq-input-gelf:
+    image: datalust/seq-input-gelf:latest
     depends_on:
       - seq
     ports:
@@ -85,11 +85,7 @@ services:
       - ./seq-data:/data
 ```
 
-The service can be started using `docker-compose up`:
-
-```shell
-$ docker-compose -p seq up -d
-```
+The service can be started using `docker-compose up`.
 
 ### Collecting Docker container logs
 
@@ -100,8 +96,8 @@ $ docker run \
     --rm \
     -it \
     --log-driver gelf \
-    --log-opt gelf-address=udp://sqelf.example.com:12201 \
+    --log-opt gelf-address=udp://seq-input-gelf.example.com:12201 \
     my-app:latest
 ```
 
-In this case the `gelf-address` option needs to resolve to the running `sqelf` container.
+In this case the `gelf-address` option needs to resolve to the running `seq-input-gelf` container.

--- a/docker-publish.ps1
+++ b/docker-publish.ps1
@@ -9,7 +9,7 @@ $major = $versionParts[0]
 $minor = $versionParts[1]
 
 $baseImage = "datalust/sqelf-ci:$version"
-$publishImages = "datalust/sqelf:latest", "datalust/sqelf:$major", "datalust/sqelf:$major.$minor", "datalust/sqelf:$version"
+$publishImages = "datalust/sqelf:latest", "datalust/sqelf:$major", "datalust/sqelf:$major.$minor", "datalust/sqelf:$version, datalust/seq-input-gelf:latest", "datalust/seq-input-gelf:$major", "datalust/seq-input-gelf:$major.$minor", "datalust/seq-input-gelf:$version"
 
 $choices  = "&Yes", "&No"
 $decision = $Host.UI.PromptForChoice("Publishing ($baseImage) as ($publishImages)", "Does this look right?", $choices, 1)


### PR DESCRIPTION
First part of renaming our inputs to be more consistent and discoverable with other Seq input applications with Docker sidecars.