### PR TITLE
Include the raw payload when diagnostics is enabled

### DIFF
--- a/sqelf/src/config.rs
+++ b/sqelf/src/config.rs
@@ -38,6 +38,7 @@ impl Config {
         };
         if is_truthy(enable_diagnostics)? {
             config.diagnostics.min_level = diagnostics::Level::Debug;
+            config.process.include_raw_payload = true;
         }
 
         Ok(config)


### PR DESCRIPTION
For #74 

Different logging drivers sometimes disagree on what the log level should be, especially when that level is just a number. This PR makes it easier to diagnose unexpected events by including the raw payload the `sqelf` server was given, before any parsing or translation was done.