### PR TITLE
Use rust_decimal for GELF timestamp so sub-second precision is not lost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +544,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
+name = "rust_decimal"
+version = "1.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01127cb8617e5e21bcf2e19b5eb48317735ca677f1d0a94833c21c331c446582"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +623,7 @@ dependencies = [
  "lazy_static",
  "libflate",
  "pin-utils",
+ "rust_decimal",
  "serde",
  "serde_derive",
  "serde_json",

--- a/sqelf/Cargo.toml
+++ b/sqelf/Cargo.toml
@@ -55,3 +55,6 @@ version = "1"
 
 [dependencies.anyhow]
 version = "1"
+
+[dependencies.rust_decimal]
+version = "1.14"

--- a/sqelf/src/process/clef.rs
+++ b/sqelf/src/process/clef.rs
@@ -69,7 +69,7 @@ impl Timestamp {
         // If the timestamp is before the epoch
         // then just return the epoch
         if ts.is_sign_negative() {
-            return Option::Some(Timestamp(SystemTime::UNIX_EPOCH));
+            return Some(Timestamp(SystemTime::UNIX_EPOCH));
         }
 
         let secs = ts.trunc().to_u64()?;

--- a/sqelf/src/process/clef.rs
+++ b/sqelf/src/process/clef.rs
@@ -66,22 +66,26 @@ impl Timestamp {
         Timestamp(SystemTime::now())
     }
 
-    pub(super) fn from_decimal(ts: Decimal) -> Self {
+    pub(super) fn from_decimal(ts: Decimal) -> Option<Self> {
         // If the timestamp is before the epoch
         // then just return the epoch
         if ts.is_sign_negative() {
-            return Timestamp(SystemTime::UNIX_EPOCH);
+            return Option::Some(Timestamp(SystemTime::UNIX_EPOCH));
         }
 
-        let secs = ts.trunc().to_i64().unwrap() as u64;
-        let nanos = {
+        if let Option::Some(secs) = ts.trunc().to_i64() {
             let mut fract = ts.fract();
-            fract.set_scale(0).unwrap();
-            let scaled_fract = fract.to_i32().unwrap() as u32;
-            scaled_fract * 10_u32.pow(9 - ts.scale())
-        };
+            if fract.set_scale(0).is_err() {
+                return Option::None;
+            }
+            if let Option::Some(scaled_fract) = fract.to_i32() {
+                let nanos = (scaled_fract as u32) * 10_u32.pow(9 - ts.scale());
+                return Option::Some(Timestamp(SystemTime::UNIX_EPOCH +
+                    Duration::new(secs as u64, nanos)));
+            }
+        }
 
-        Timestamp(SystemTime::UNIX_EPOCH + Duration::new(secs, nanos))
+        Option::None
     }
 }
 

--- a/sqelf/src/process/gelf.rs
+++ b/sqelf/src/process/gelf.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use rust_decimal::Decimal;
 
 #[derive(Debug, Deserialize)]
 pub(super) struct Message<TString, TMessage = TString> {
@@ -7,7 +8,7 @@ pub(super) struct Message<TString, TMessage = TString> {
     pub(super) host: Option<TString>,
     pub(super) short_message: TMessage,
     pub(super) full_message: Option<TMessage>,
-    pub(super) timestamp: Option<f64>,
+    pub(super) timestamp: Option<Decimal>,
     pub(super) level: Option<u8>,
 
     // Deprecated built-ins, still may be present

--- a/sqelf/src/process/mod.rs
+++ b/sqelf/src/process/mod.rs
@@ -181,7 +181,7 @@ where
         // Set the timestamp
         if clef.timestamp.is_none() {
             clef.timestamp = timestamp
-                .map(clef::Timestamp::from_float)
+                .map(clef::Timestamp::from_decimal)
                 .or_else(|| Some(clef::Timestamp::now()));
         }
 
@@ -304,7 +304,7 @@ mod tests {
                 }
 
                 let expected = json!({
-                    "@t": "2013-11-21T17:11:02.307000000Z",
+                    "@t": "2013-11-21T17:11:02.307200000Z",
                     "@l": "alert",
                     "@m": "A short message that helps you identify what is going on",
                     "@x": "Backtrace here",
@@ -387,7 +387,7 @@ mod tests {
             "host": "example.org",
             "short_message": "A short message that helps you identify what is going on",
             "full_message": "Backtrace here",
-            "timestamp": 1385053862.3072,
+            "timestamp": 1385053862.04736,
             "level": 1,
             "_user_id": 9001,
             "_some_info": "foo",
@@ -403,7 +403,7 @@ mod tests {
                 }
 
                 let expected = json!({
-                    "@t": "2013-11-21T17:11:02.307000000Z",
+                    "@t": "2013-11-21T17:11:02.047360000Z",
                     "@l": "alert",
                     "@m": "A short message that helps you identify what is going on",
                     "@x": "Backtrace here",

--- a/sqelf/src/process/mod.rs
+++ b/sqelf/src/process/mod.rs
@@ -181,7 +181,7 @@ where
         // Set the timestamp
         if clef.timestamp.is_none() {
             clef.timestamp = timestamp
-                .map(clef::Timestamp::from_decimal)
+                .and_then(clef::Timestamp::from_decimal)
                 .or_else(|| Some(clef::Timestamp::now()));
         }
 


### PR DESCRIPTION
I had noticed that timestamp sub-second precision was being lost when importing GELF data into Seq. When GELF  events with microsecond resolution were imported, events in Seq were truncated or rounded to millisecond resolution.

In `Timestamp::from_float` method the code truncates or rounds to milliseconds. I assume that is to avoid rounding errors from floating-point calculations using `f64`. It is better to use a decimal type that can preserve precision.

This proposal is to use the [`rust_decimal`](https://docs.rs/crate/rust_decimal/1.14.3) type. This type makes it straightforward to extract the whole-number part of the decimal and to adjust the scale of the fractional part so it represents nanoseconds.