### PR TITLE
Add a target for ARM

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,8 @@
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "linker=rust-lld"]
 
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "linker=rust-lld"]
+
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/Seq.Input.Gelf.nuspec
+++ b/Seq.Input.Gelf.nuspec
@@ -16,6 +16,7 @@
     <file src="seq-input-gelf.d.json" target="" />
     <file src="target/x86_64-pc-windows-msvc/release/sqelf.exe" target="win-x64" />
     <file src="target/x86_64-unknown-linux-musl/release/sqelf" target="linux-x64/sqelf" />
+    <file src="target/aarch64-unknown-linux-musl/release/sqelf" target="linux-arm64/sqelf" />
     <file src="asset/seq-input-gelf.png" target="" />
   </files>
 </package>

--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -68,6 +68,7 @@ function Invoke-LinuxBuild
     Write-BeginStep $MYINVOCATION
 
     Run-Command -Exe cargo -ArgumentList 'build', '--bin sqelf', '--release', '--target x86_64-unknown-linux-musl'
+    Run-Command -Exe cargo -ArgumentList 'build', '--bin sqelf', '--release', '--target aarch64-unknown-linux-musl'
 }
 function Invoke-LinuxTests
 {

--- a/ci/linux-x64/setup.sh
+++ b/ci/linux-x64/setup.sh
@@ -7,6 +7,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- --default-host x86_64-unknown-linux-gn
 export PATH="$HOME/.cargo/bin:$PATH"
 
 rustup target add x86_64-unknown-linux-musl
+rustup target add aarch64-unknown-linux-musl
 
 ls /home/appveyor
 ls /home/appveyor/.cargo

--- a/ci/win-x64/setup.ps1
+++ b/ci/win-x64/setup.ps1
@@ -12,4 +12,7 @@ $env:Path = "C:\Users\appveyor\.cargo\bin;$env:Path"
 & rustup target add x86_64-unknown-linux-musl
 if ($LASTEXITCODE) { exit 1 }
 
+& rustup target add aarch64-unknown-linux-musl
+if ($LASTEXITCODE) { exit 1 }
+
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
This PR gets us an untested ARM binary in the `Seq.Input.Gelf` package. I'll give the binary a bit of a smoke-test on my ARM Linux environment.