### PR TITLE
Use a few fallback props if we don't end up with a message

### DIFF
--- a/sqelf/src/process/mod.rs
+++ b/sqelf/src/process/mod.rs
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn from_gelf_inner_json_fallback() {
-        let clef = json!({
+        let inner_json = json!({
             "message": "A short message that helps {user_id} identify what is going on"
         });
 
@@ -410,7 +410,7 @@ mod tests {
             "version": "1.1",
             "timestamp": 1385053862.3072,
             "host": "example.org",
-            "short_message": clef.to_string(),
+            "short_message": inner_json.to_string(),
             "level": 6,
         });
 


### PR DESCRIPTION
Part of #95 

If we get an embedded JSON message that doesn't include the `@m` or `@mt` properties that CLEF expects then we'll try find some suitable property to use from within the event itself. We could apply this same approach to other built-ins like the level or timestamp.