### PR TITLE
Build an arm container of sqelf

### DIFF
--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -83,6 +83,8 @@ function Invoke-DockerBuild
     Write-BeginStep $MYINVOCATION
 
     docker buildx build --platform linux/amd64 --file dockerfiles/x86_64-unknown-linux-musl.Dockerfile -t sqelf-ci:latest-x64 .
+    if ($LASTEXITCODE) { exit 1 }
+
     docker buildx build --platform linux/arm64 --file dockerfiles/aarch64-unknown-linux-musl.Dockerfile -t sqelf-ci:latest-arm64 .
     if ($LASTEXITCODE) { exit 1 }
 }

--- a/ci/linux-x64/setup.sh
+++ b/ci/linux-x64/setup.sh
@@ -9,5 +9,8 @@ export PATH="$HOME/.cargo/bin:$PATH"
 rustup target add x86_64-unknown-linux-musl
 rustup target add aarch64-unknown-linux-musl
 
+docker run --privileged --rm docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+sudo service docker restart
+
 ls /home/appveyor
 ls /home/appveyor/.cargo

--- a/dockerfiles/aarch64-unknown-linux-musl.Dockerfile
+++ b/dockerfiles/aarch64-unknown-linux-musl.Dockerfile
@@ -1,0 +1,12 @@
+FROM --platform=linux/arm64 datalust/seqcli:latest
+
+COPY target/aarch64-unknown-linux-musl/release/sqelf /bin/sqelf
+COPY dockerfiles/run.sh /run.sh
+
+EXPOSE 12201
+
+ENV SEQ_ADDRESS=http://localhost:5341
+ENV SEQ_API_KEY=
+ENV GELF_ADDRESS=
+
+ENTRYPOINT ["/run.sh"]

--- a/dockerfiles/aarch64-unknown-linux-musl.Dockerfile
+++ b/dockerfiles/aarch64-unknown-linux-musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 datalust/seqcli:latest
+FROM --platform=linux/arm/v8 datalust/seqcli:latest
 
 COPY target/aarch64-unknown-linux-musl/release/sqelf /bin/sqelf
 COPY dockerfiles/run.sh /run.sh

--- a/dockerfiles/x86_64-unknown-linux-musl.Dockerfile
+++ b/dockerfiles/x86_64-unknown-linux-musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM datalust/seqcli:latest
+FROM --platform=linux/amd64 datalust/seqcli:latest
 
 COPY target/x86_64-unknown-linux-musl/release/sqelf /bin/sqelf
 COPY dockerfiles/run.sh /run.sh


### PR DESCRIPTION
Closes #94 

This finishes up the work needed to package the GELF input for ARM. It uses the same manifest approach that we have in other projects for stitching cross-platform containers together.