### PR TITLE
Publish assets automatically from main and dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CI_BUILD_NUMBER_BASE: ${{ github.run_number }}
   CI_TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
-  CI_PUBLISH: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+  CI_EVENT: ${{ github.event_name }}
 
 jobs:
   build-windows:

--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -117,7 +117,7 @@ function Invoke-NuGetPack($version)
 
 function Publish-NuPkg($version)
 {
-    foreach ($nupkg in Get-ChildItem artifacts/*.nupkg) {
+    foreach ($nupkg in Get-ChildItem publish/*.nupkg) {
         & dotnet nuget push -k $env:NUGET_API_KEY -s https://api.nuget.org/v3/index.json "$nupkg"
         if($LASTEXITCODE -ne 0) { throw "Publishing failed" }
     }
@@ -128,7 +128,7 @@ function Publish-GitHubRelease($version)
 {
     Write-Output "build: Creating release for version $version"
 
-    iex "gh release create v$version --title v$version --generate-notes $(get-item ./artifacts/*.nupkg) $(get-item ./artifacts/*.snupkg)"
+    iex "gh release create v$version --title v$version --generate-notes $(get-item ./publish/*.nupkg) $(get-item ./publish/*.snupkg)"
 }
 
 function Publish-Container($version)

--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -117,6 +117,8 @@ function Invoke-NuGetPack($version)
 
 function Publish-NuPkg($version)
 {
+    Write-BeginStep $MYINVOCATION
+    
     foreach ($nupkg in Get-ChildItem publish/*.nupkg) {
         & dotnet nuget push -k $env:NUGET_API_KEY -s https://api.nuget.org/v3/index.json "$nupkg"
         if($LASTEXITCODE -ne 0) { throw "Publishing failed" }
@@ -126,6 +128,8 @@ function Publish-NuPkg($version)
 
 function Publish-GitHubRelease($version)
 {
+    Write-BeginStep $MYINVOCATION
+    
     Write-Output "build: Creating release for version $version"
 
     iex "gh release create v$version --title v$version --generate-notes $(get-item ./publish/*.nupkg) $(get-item ./publish/*.snupkg)"

--- a/ci/build-deps.ps1
+++ b/ci/build-deps.ps1
@@ -115,6 +115,22 @@ function Invoke-NuGetPack($version)
     if ($LASTEXITCODE) { exit 1 }
 }
 
+function Publish-NuPkg($version)
+{
+    foreach ($nupkg in Get-ChildItem artifacts/*.nupkg) {
+        & dotnet nuget push -k $env:NUGET_API_KEY -s https://api.nuget.org/v3/index.json "$nupkg"
+        if($LASTEXITCODE -ne 0) { throw "Publishing failed" }
+    }
+}
+
+
+function Publish-GitHubRelease($version)
+{
+    Write-Output "build: Creating release for version $version"
+
+    iex "gh release create v$version --title v$version --generate-notes $(get-item ./artifacts/*.nupkg) $(get-item ./artifacts/*.snupkg)"
+}
+
 function Publish-Container($version)
 {
     Write-BeginStep $MYINVOCATION

--- a/ci/linux-x64/build.ps1
+++ b/ci/linux-x64/build.ps1
@@ -62,8 +62,8 @@ Build-TestAppContainer
 Invoke-SmokeTest("udp")
 Invoke-SmokeTest("tcp")
 
-if ($env:CI_PUBLISH) {
-    Publish-Container (Get-SemVer $shortver)
+if ($env:CI_EVENT -eq "push" -and $env:DOCKER_TOKEN -ne "") {
+    Publish-Container (Get-SemVer)
 }
 else {
     Write-Output "Not publishing Docker container"

--- a/ci/win-x64/build.ps1
+++ b/ci/win-x64/build.ps1
@@ -23,6 +23,12 @@ Invoke-WindowsBuild
 Invoke-WindowsTests
 # NOTE: We're relying on GitHub Actions to copy the linux binary across here instead of building locally
 # Invoke-LinuxBuild
-Invoke-NuGetPack (Get-SemVer $shortver)
+Invoke-NuGetPack ($version)
 
-Pop-Location
+if ($env:CI_PUBLISH) {
+    Publish-NuPkg ($version)
+    Publish-GitHubRelease($version)
+}
+else {
+    Write-Output "Not publishing NUPKG or GitHub release"
+}

--- a/ci/win-x64/build.ps1
+++ b/ci/win-x64/build.ps1
@@ -25,7 +25,7 @@ Invoke-WindowsTests
 # Invoke-LinuxBuild
 Invoke-NuGetPack ($version)
 
-if ($env:CI_PUBLISH) {
+if ($env:CI_EVENT -eq "push" -and $env:NUGET_API_KEY -ne "") {
     Publish-NuPkg ($version)
     Publish-GitHubRelease($version)
 }


### PR DESCRIPTION
The port of CI to Actions seems to have dropped NuGet package publishing, and missed adding GitHub release publishing. I think I've got those covered here, both only on `main`.